### PR TITLE
Change the docker url for main and non-main branches

### DIFF
--- a/.github/workflows/Docker.yml
+++ b/.github/workflows/Docker.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.actor }}/${{ github.event.repository.name }}
+  IMAGE_NAME: fmiexchange.jl
 
 jobs:
   build-and-push-image:
@@ -34,19 +34,23 @@ jobs:
         shell: bash
         env:
             REFNAME: ${{ github.head_ref || github.ref_name }}
+            ACTOR: ${{ github.actor }}
+            REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
             if [ $REFNAME == "main" ]
             then
                 echo "DOCKERTAG=latest" >> $GITHUB_ENV;
+                echo "IMAGE_PREFIX=$REPOSITORY_OWNER" >> $GITHUB_ENV;
             else
                 echo "DOCKERTAG=$REFNAME" >> $GITHUB_ENV;
+                echo "IMAGE_PREFIX=$ACTOR" >> $GITHUB_ENV;
             fi
 
       - id: lowercasetag
         name: Make the docker url lower case
         uses: ASzc/change-string-case-action@v1
         with:
-            string: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DOCKERTAG }}
+            string: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ env.IMAGE_NAME }}:${{ env.DOCKERTAG }}
 
       - name: Build and push Docker image
         id: push


### PR DESCRIPTION
Automatically pusing docker images is tricky due to permission problems.
- Workflows running on forks don't have permission to push images to the electa-git package registry
- Workflows running in PRs may need to use an updated docker image

Solution:

- If the workflow runs on the main branch, aim to push to ` ${{ github.repository_owner }}/fmiexchange.jl`. This should result in the docker workflow succeeding after a merge.
- If the workflow doesn't run on the main branch, then use `${{ github.actor }}/fmiexchange.jl` which allows for testing on forks and allows PRs to use images hosted on the forks where they're coming from. 

The solution isn't perfect (for example when multiple collaborate on a PR), but it should do for now